### PR TITLE
#36 [feat] : 메모 기록 페이지 UI 구현

### DIFF
--- a/src/components/common/button/ButtonStyle.tsx
+++ b/src/components/common/button/ButtonStyle.tsx
@@ -7,6 +7,7 @@ const popupCommonStyles = css`
   font-size: 1rem;
   font-weight: 600;
   border-radius: 0.75rem;
+  white-space: nowrap;
 `;
 
 const BUTTON_STYLES = {

--- a/src/components/common/input/Input.tsx
+++ b/src/components/common/input/Input.tsx
@@ -2,7 +2,7 @@ import * as S from './InputStyle';
 
 interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   isError: boolean;
-  errorMessage: string;
+  errorMessage?: string;
 }
 
 /**

--- a/src/components/common/modal/ModalStyle.tsx
+++ b/src/components/common/modal/ModalStyle.tsx
@@ -10,7 +10,7 @@ export const Background = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  z-index: 100;
+  z-index: 1100;
 `;
 
 export const Modal = styled.div`

--- a/src/components/layout/tabBar/TabBar.tsx
+++ b/src/components/layout/tabBar/TabBar.tsx
@@ -9,6 +9,7 @@ interface TabBarProps {
   centerText?: string;
   onClick?: () => void;
   onClickBackIcon?: () => void;
+  $isDisabled?: boolean;
 }
 /**
  *
@@ -27,6 +28,7 @@ export const TabBar = ({
   centerText,
   onClick,
   onClickBackIcon,
+  $isDisabled,
 }: TabBarProps) => {
   const navigate = useNavigate();
 
@@ -43,7 +45,7 @@ export const TabBar = ({
       />
       {leftText && <S.LeftText>{leftText}</S.LeftText>}
       {centerText && <S.CenterText>{centerText}</S.CenterText>}
-      {rightText && <S.Text onClick={onClick}>{rightText}</S.Text>}
+      {rightText && <S.Text onClick={onClick} $isDisabled={$isDisabled}>{rightText}</S.Text>}
       {icon && <S.Icon src={icon} alt="아이콘" onClick={onClick} />}
     </S.TabBar>
   );

--- a/src/components/layout/tabBar/TabBar.tsx
+++ b/src/components/layout/tabBar/TabBar.tsx
@@ -9,7 +9,7 @@ interface TabBarProps {
   centerText?: string;
   onClick?: () => void;
   onClickBackIcon?: () => void;
-  $isDisabled?: boolean;
+  isDisabled?: boolean;
 }
 /**
  *
@@ -19,6 +19,7 @@ interface TabBarProps {
  * @param centerText - (optional) 가운데 자리에 들어갈 글씨
  * @param onClick - (optional) rightText나 icon을 클릭 시 수행하는 함수
  * @param onClickBackIcon - (optional) 이전 버튼을 클릭 시 수행하는 함수, 전달되지 않을 경우 이전 페이지로 이동하는 함수 수행
+ * @param isDisabled - (optional) rightText를 클릭 시 수행하는 함수, 전달되지 않을 경우 이전 페이지로 이동하는 함수 수행
  * @returns
  */
 export const TabBar = ({
@@ -28,7 +29,7 @@ export const TabBar = ({
   centerText,
   onClick,
   onClickBackIcon,
-  $isDisabled,
+  isDisabled,
 }: TabBarProps) => {
   const navigate = useNavigate();
 
@@ -45,7 +46,7 @@ export const TabBar = ({
       />
       {leftText && <S.LeftText>{leftText}</S.LeftText>}
       {centerText && <S.CenterText>{centerText}</S.CenterText>}
-      {rightText && <S.Text onClick={onClick} $isDisabled={$isDisabled}>{rightText}</S.Text>}
+      {rightText && <S.Text onClick={onClick} $isDisabled={isDisabled}>{rightText}</S.Text>}
       {icon && <S.Icon src={icon} alt="아이콘" onClick={onClick} />}
     </S.TabBar>
   );

--- a/src/components/layout/tabBar/TabBarStyle.tsx
+++ b/src/components/layout/tabBar/TabBarStyle.tsx
@@ -1,5 +1,9 @@
 import styled from 'styled-components';
 
+interface TextProps {
+  $isDisabled?: boolean;
+}
+
 export const TabBar = styled.nav`
   position: fixed;
   top: 0;
@@ -29,9 +33,10 @@ export const CenterText = styled.h6`
   color: ${({ theme }) => theme.colors.gray900};
 `;
 
-export const Text = styled.h6`
+export const Text = styled.h6<TextProps>`
   color: ${({ theme }) => theme.colors.gray700};
   cursor: pointer;
+  $isDisabled ? theme.colors.gray300 : theme.colors.gray700};
 `;
 
 export const LeftText = styled.span`

--- a/src/pages/memoPage/MemoPage.tsx
+++ b/src/pages/memoPage/MemoPage.tsx
@@ -103,6 +103,7 @@ export const MemoPage = () => {
   const clearTempMemo = () => {
     localStorage.removeItem('tempMemo');
     setShowModal(false);
+    navigate('/');
   };
 
   const isSaveDisabled = !title && !memo;

--- a/src/pages/memoPage/MemoPage.tsx
+++ b/src/pages/memoPage/MemoPage.tsx
@@ -1,17 +1,171 @@
-import { ChangeEvent, useState } from 'react';
+import { ChangeEvent, useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Memo } from '@components/memo/Memo';
+import { Input } from '@components/common/input/Input';
+import { SelectBox } from '@components/common/selectbox/SelectBox';
+import { TabBar } from '@components/layout/tabBar/TabBar';
+import { DetailModal } from '@components/common/modal/DetailModal';
+import * as S from './MemoPageStyle';
+
+const getFormattedDate = () => {
+  const date = new Date();
+  const year = date.getFullYear().toString().slice(-2);
+  const month = (date.getMonth() + 1).toString().padStart(2, '0');
+  const day = date.getDate().toString().padStart(2, '0');
+  return `${year}${month}${day}`;
+};
+
+const DUMMY_MEMO = {
+  title: '오늘의 회고',
+  category: '카테고리1',
+  memo: '오늘 하루 동안 있었던 일을 기록합니다...'
+};
 
 export const MemoPage = () => {
+  const navigate = useNavigate();
+  const [title, setTitle] = useState('');
+  const [category, setCategory] = useState('');
   const [memo, setMemo] = useState('');
+  const [showModal, setShowModal] = useState(false);
+  const [showTempDataModal, setShowTempDataModal] = useState(false);
+  const [tempMemo, setTempMemo] = useState<{
+    title: string;
+    category: string;
+    memo: string;
+  } | null>(null);
 
-  const handleChangeMemo = (e: ChangeEvent<HTMLTextAreaElement>) => {
-    setMemo(e.target.value);
-    console.log(memo);
+  useEffect(() => {
+    // 컴포넌트 마운트 시 더미데이터를 임시저장
+    localStorage.setItem('tempMemo', JSON.stringify(DUMMY_MEMO));
+
+    // 임시저장된 메모 확인 및 모달 표시
+    const savedMemo = localStorage.getItem('tempMemo');
+    if (savedMemo) {
+      setTempMemo(JSON.parse(savedMemo));
+      setShowTempDataModal(true);
+    }
+  }, []);
+
+  const saveTempMemo = (title: string, category: string, memo: string) => {
+    const titleToSave = title || getFormattedDate();
+    localStorage.setItem('tempMemo', JSON.stringify({
+      title: titleToSave,
+      category,
+      memo
+    }));
   };
 
+  const handleBackButton = () => {
+    if ((title || getFormattedDate()) && memo) {
+      saveTempMemo(title, category, memo);
+      setShowModal(true);
+    } else {
+      navigate(-1);
+    }
+  };
+
+  const handleChangeTitle = (e: ChangeEvent<HTMLInputElement>) => {
+    const newTitle = e.target.value;
+    setTitle(newTitle);
+    saveTempMemo(newTitle, category, memo);
+  };
+
+  const handleChangeCategory = (value: string) => {
+    setCategory(value);
+    saveTempMemo(title, value, memo);
+  };
+
+  const handleChangeMemo = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    const newMemo = e.target.value;
+    setMemo(newMemo);
+    saveTempMemo(title, category, newMemo);
+  };
+
+  const handleSaveButton = () => {
+    const titleToSave = title || getFormattedDate();
+    console.log('저장되었습니다.', {
+      title: titleToSave,
+      category,
+      memo
+    });
+    clearTempMemo();
+  };
+
+  const restoreTempMemo = () => {
+    if (tempMemo) {
+      setTitle(tempMemo.title);
+      setCategory(tempMemo.category);
+      setMemo(tempMemo.memo);
+    }
+    setShowModal(false);
+  };
+
+  const clearTempMemo = () => {
+    localStorage.removeItem('tempMemo');
+    setShowModal(false);
+  };
+
+  const isSaveDisabled = !title && !memo;
+
   return (
-    <div>
-      <Memo memo={memo} onChange={handleChangeMemo} />
-    </div>
+    <S.Container>
+      <TabBar
+        onClickBackIcon={handleBackButton}
+        centerText="경험 기록"
+        rightText="저장"
+        onClick={handleSaveButton}
+        $isDisabled={isSaveDisabled}
+      />
+      <S.Form>
+        <S.Label>경험의 제목을 적어주세요</S.Label>
+        <S.InputContainer>
+          <Input
+            placeholder={getFormattedDate()}
+            value={title}
+            onChange={handleChangeTitle}
+            isError={false}
+            errorMessage={''}
+          />
+        </S.InputContainer>
+        <S.Label>경험의 카테고리를 선택해주세요</S.Label>
+        <S.InputContainer>
+          <SelectBox
+            select={category}
+            onChange={handleChangeCategory}
+            selectData={['카테고리1', '카테고리2', '카테고리3']}
+          />
+        </S.InputContainer>
+        <S.Label>경험 기록</S.Label>
+        <Memo memo={memo} onChange={handleChangeMemo} />
+      </S.Form>
+      {showModal && (
+        <DetailModal
+          text="작성 중인 내용을 임시 저장할까요?"
+          description="새로 작성하면 기존 기록은 삭제돼요."
+          leftButtonText="나가기"
+          rightButtonText="저장하기"
+          onClickBackground={() => setShowModal(false)}
+          onClickLeft={clearTempMemo}
+          onClickRight={restoreTempMemo}
+        />
+      )}
+      {showTempDataModal && (
+        <DetailModal
+          text={`최근 작성 내용이 있어요\n이어서 작성하시겠어요?`}
+          description="새로 작성하면 기존 기록은 모두 삭제돼요."
+          leftButtonText="새로 작성하기"
+          rightButtonText="이어서 작성하기"
+          onClickBackground={() => setShowTempDataModal(false)}
+          onClickLeft={() => {
+            localStorage.removeItem('tempMemo');
+            setShowTempDataModal(false);
+          }}
+          onClickRight={() => {
+            restoreTempMemo();
+            setShowTempDataModal(false);
+          }}
+        />
+      )}
+    </S.Container>
   );
 };

--- a/src/pages/memoPage/MemoPageStyle.tsx
+++ b/src/pages/memoPage/MemoPageStyle.tsx
@@ -1,0 +1,29 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.625rem;
+  position: relative;
+  width: 100%;
+  height: 100vh;
+  margin-top: 60px;
+`;
+
+export const Label = styled.h6`
+  color: ${({ theme }) => theme.colors.gray900};
+  margin-bottom: 0.625rem;
+  margin-top: 0.625rem;
+`;
+
+export const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 0.625rem;
+  width: 100%;
+  padding: 0 1.25rem;
+`;
+
+export const InputContainer = styled.div`
+  margin-bottom: 1.25rem;
+`;


### PR DESCRIPTION
## #️⃣연관된 이슈

>  연관된 이슈 번호를 작성해주세요.
#36 

## 📝작업 내용

> 작업한 내용을 작성해주세요.
- 메모 페이지 UI 구현
- 임시저장 기능 구현

### 스크린샷 (선택)
![스크린샷 2024-11-03 오후 3 32 20](https://github.com/user-attachments/assets/a2bcda37-28b0-40fc-a7d7-bf2abc76c0cb)
![스크린샷 2024-11-03 오후 3 32 28](https://github.com/user-attachments/assets/9bda4b57-ccf5-40a5-ada1-302ebb7e154f)
![스크린샷 2024-11-03 오후 3 32 41](https://github.com/user-attachments/assets/af262498-75ed-44dd-9c95-950c82d45ce9)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- 코드가 좀 길어진 것 같아서 걱정입니당... 아래 함수 설명 보고 질문할 거 있으면 편하게 질문해주세용!!
- 현재는 일단 더미데이터로 경험 기록 내용이 존재하기 때문에, 홈에서 메모 기록을 누르면 바로 임시 저장 불러오기 모달창이 뜨는 상태입니다
- 현재는 작성한 기록을 저장하면 따로 모달창이 뜨지는 않고, 바로 홈으로 넘어가게 되어있습니당 이 부분은 디자인된 게 따로 없길래 일단 이렇게 해놨는데 "저장되었습니다!" 같은 팝업을 띄우는 게 나을까용?  

```
saveTempMemo: 제목, 카테고리, 메모 내용을 로컬 스토리지에 tempMemo로 임시 저장합니다. 제목이 비어 있으면 날짜로 기본 제목을 설정합니다.

handleBackButton: 뒤로 가기 버튼 클릭 시, 제목이나 메모가 있으면 임시 저장 후 모달을 보여주고, 그렇지 않으면 이전 페이지로 돌아갑니다.

handleChangeTitle, handleChangeCategory, handleChangeMemo: 각각 제목, 카테고리, 메모가 변경될 때 상태를 업데이트하고, 변경된 내용을 즉시 임시 저장합니다.

handleSaveButton: 저장 버튼을 클릭하면, 제목과 메모 내용을 콘솔에 출력하고 임시 저장을 초기화합니다.

restoreTempMemo: 임시 저장된 tempMemo 데이터를 상태에 복원하여 화면에 표시하고, 모달을 닫습니다.

clearTempMemo: 로컬 스토리지에서 tempMemo 데이터를 삭제하고 모달을 닫으며, 홈 화면으로 이동합니다.
```

